### PR TITLE
Allow inviting unbridged users to portal rooms.

### DIFF
--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -60,6 +60,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.encryption.allow")
         copy("bridge.encryption.default")
         copy("bridge.delivery_receipts")
+        copy("bridge.allow_invites")
 
         copy_dict("bridge.permissions")
 

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -121,6 +121,8 @@ bridge:
     # Whether or not the bridge should send a read receipt from the bridge bot when a message has
     # been sent to Facebook.
     delivery_receipts: false
+    # Whether to allow inviting arbitrary mxids to portal rooms
+    allow_invites: false
 
     # Permissions for using the bridge.
     # Permitted values:

--- a/mautrix_facebook/matrix.py
+++ b/mautrix_facebook/matrix.py
@@ -150,7 +150,7 @@ class MatrixHandler(BaseMatrixHandler):
                                                "You are not whitelisted on this "
                                                "Facebook Messenger bridge.")
             return
-        elif not await user.is_logged_in():
+        elif not await user.is_logged_in() and not self.config["bridge.allow_invites"]:
             await portal.main_intent.kick_user(room_id, user.mxid, "You are not logged in to this "
                                                                    "Facebook Messenger bridge.")
             return

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -436,8 +436,7 @@ class Portal(BasePortal):
         except MatrixError:
             members = []
         for user_id in members:
-            puppet = p.Puppet.get_by_mxid(user_id, create=False)
-            if not puppet:
+            if p.Puppet.get_id_from_mxid(user_id) is None:
                 return False
         return True
 

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -429,6 +429,18 @@ class Portal(BasePortal):
         except MatrixError:
             pass
 
+    @staticmethod
+    async def are_only_puppets_left(intent: IntentAPI, room_id: RoomID) -> bool:
+        try:
+            members = await intent.get_room_members(room_id)
+        except MatrixError:
+            members = []
+        for user_id in members:
+            puppet = p.Puppet.get_by_mxid(user_id, create=False)
+            if not puppet:
+                return False
+        return True
+
     async def unbridge(self) -> None:
         await self.cleanup_room(self.main_intent, self.mxid, "Room unbridged", puppets_only=True)
         self.delete()
@@ -579,8 +591,9 @@ class Portal(BasePortal):
     async def handle_matrix_leave(self, user: 'u.User') -> None:
         if self.is_direct:
             self.log.info(f"{user.mxid} left private chat portal with {self.fbid},"
-                          " cleaning up and deleting...")
-            await self.cleanup_and_delete()
+                          " cleaning up and deleting (if only puppets remain)...")
+            if await self.are_only_puppets_left(self.main_intent, self.mxid):
+                await self.cleanup_and_delete()
         else:
             self.log.debug(f"{user.mxid} left portal to {self.fbid}")
 

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -429,17 +429,6 @@ class Portal(BasePortal):
         except MatrixError:
             pass
 
-    @staticmethod
-    async def are_only_puppets_left(intent: IntentAPI, room_id: RoomID) -> bool:
-        try:
-            members = await intent.get_room_members(room_id)
-        except MatrixError:
-            members = []
-        for user_id in members:
-            if p.Puppet.get_id_from_mxid(user_id) is None:
-                return False
-        return True
-
     async def unbridge(self) -> None:
         await self.cleanup_room(self.main_intent, self.mxid, "Room unbridged", puppets_only=True)
         self.delete()
@@ -589,9 +578,9 @@ class Portal(BasePortal):
 
     async def handle_matrix_leave(self, user: 'u.User') -> None:
         if self.is_direct:
-            self.log.info(f"{user.mxid} left private chat portal with {self.fbid},"
-                          " cleaning up and deleting (if only puppets remain)...")
-            if await self.are_only_puppets_left(self.main_intent, self.mxid):
+            self.log.info(f"{user.mxid} left private chat portal with {self.fbid}")
+            if user.fbid == self.fb_receiver:
+                self.log.info(f"{user.mxid} was the recipient of this portal. Cleaning up and deleting...")
                 await self.cleanup_and_delete()
         else:
             self.log.debug(f"{user.mxid} left portal to {self.fbid}")


### PR DESCRIPTION
Requires setting the new "bridge.allow_invites" setting to true.

Also, don't clean & delete a portal room when someone leaves it
if there are any non-puppet users still in the room.