### PR TITLE
Populate required body field for m.sticker events

### DIFF
--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -595,10 +595,11 @@ class Portal(BasePortal):
         # TODO handle animated stickers?
         mxc, mime, size, decryption_info = await self._reupload_fb_file(
             sticker.url, intent, encrypt=self.encrypted)
+        body = ('No label' if sticker.label is None else sticker.label)
         return await self._send_message(intent, event_type=EventType.STICKER,
                                         content=MediaMessageEventContent(
                                             url=mxc, file=decryption_info,
-                                            msgtype=MessageType.STICKER, body=sticker.label,
+                                            msgtype=MessageType.STICKER, body=body,
                                             info=ImageInfo(width=sticker.width, size=size,
                                                            height=sticker.height, mimetype=mime),
                                             relates_to=self._get_facebook_reply(reply_to)))


### PR DESCRIPTION
Some stickers come with a valid label, while others come with
label=None.

Those that have a None label currently end up on the homeserver
without a `body` field.

As per the Client Server spec
(https://matrix.org/docs/spec/client_server/r0.6.0#m-sticker),
the body field is required.

Homeservers (like Synapse) should probably reject m.sticker events
which violate the spec, but that doesn't seem to be the case.

Certain clients, like nheko, currently drop `m.sticker` events
which lack a `body` field.
(https://github.com/Nheko-Reborn/nheko/issues/166#issuecomment-614606693)
Such clients should probably be made to tolerate bad data better.

With this patch, we make sure to always pass along at least some label,
to comply with the spec and not break nheko and potentially others.