### PR TITLE
Fix datetime's timezone being lost with SQLite

### DIFF
--- a/mautrix_facebook/db/message.py
+++ b/mautrix_facebook/db/message.py
@@ -16,10 +16,12 @@
 from typing import Optional, Iterable, List
 from datetime import datetime
 
-from sqlalchemy import Column, String, DateTime, SmallInteger, UniqueConstraint, and_
+from sqlalchemy import Column, String, SmallInteger, UniqueConstraint, and_
 
 from mautrix.types import RoomID, EventID
 from mautrix.util.db import Base
+
+from .types import UTCDateTime
 
 
 class Message(Base):
@@ -31,7 +33,7 @@ class Message(Base):
     fb_chat: str = Column(String(127), nullable=True)
     fb_receiver: str = Column(String(127), primary_key=True)
     index: int = Column(SmallInteger, primary_key=True, default=0)
-    date: Optional[datetime] = Column(DateTime(timezone=True), nullable=True)
+    date: Optional[datetime] = Column(UTCDateTime(timezone=True), nullable=True)
 
     __table_args__ = (UniqueConstraint("mxid", "mx_room", name="_mx_id_room"),)
 

--- a/mautrix_facebook/db/types/__init__.py
+++ b/mautrix_facebook/db/types/__init__.py
@@ -1,0 +1,30 @@
+from datetime import timezone
+
+import sqlalchemy.types as types
+
+
+class UTCDateTime(types.TypeDecorator):
+    """Decorates the SQLAlchemy DateTime type to work with UTC datetimes.
+
+    It supposes we only manipulate UTC datetime. If the timezone is not set when saving or reading
+    a value, the UTC timezone is set. If a timezone is set, it ensures the datetime is converted to
+    UTC before saving it.
+    This is useful when working with SQLite as the SQLalchemy DateTime type loses the timezone
+    information when saving a datetime on this database.
+    """
+    impl = types.DateTime
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            elif value.tzinfo != timezone.utc:
+                value = value.astimezone(timezone.utc)
+
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        else:
+            return value


### PR DESCRIPTION
Hi,

I finally took some time to work on this backfill / timezone issue with SQLite. As I already found it in [SQLAlchemy documenation](https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#sqlalchemy.dialects.sqlite.DATETIME), `DateTime` are correctly managed by converting them to text back and forth. The thing I missed is that the timezone **is not** part of the saved text.

This [stackoverflow issue](https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite) explains why:
> Python's strptime methods don't support the %z formatting directive, so there would be no way to get the timezone back out of the string in the database.

Yep. Shame on you, Python.

So I worked out a solution that supposes we **always** store datetime in UTC. It does the following:
* if the datetime we want to save to db does not have a timezone, set it to UTC
* if the datetime we want to save to db have a timezone not being UTC, convert it to UTC
* if the datetime we want to load from db does not have a timezone, set it to UTC

<details><summary>Here is a little example.</summary>

```Python
from datetime import datetime, timezone

from sqlalchemy import Column, DateTime, Integer, create_engine
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.orm import sessionmaker
import sqlalchemy.types as types


engine = create_engine("sqlite:///test.db", echo=True)
Base = declarative_base()
Session = sessionmaker(bind=engine)


class UTCDateTime(types.TypeDecorator):
    impl = types.DateTime

    def process_bind_param(self, value, dialect):
        if value is not None:
            if value.tzinfo is None:
                value = value.replace(tzinfo=timezone.utc)
            elif value.tzinfo != timezone.utc:
                value = value.astimezone(timezone.utc)

        return value

    def process_result_value(self, value, dialect):
        if value is not None and value.tzinfo is None:
            return value.replace(tzinfo=timezone.utc)
        else:
            return value


class Test(Base):
    __tablename__ = "test"

    id = Column(Integer, primary_key=True)
    date = Column(UTCDateTime(timezone=True))


if __name__ == "__main__":
    try:
        Base.metadata.create_all(engine)
    except:
        pass

    now_utc = datetime.now().astimezone(timezone.utc)
    now_without_tz = datetime.now()
    now_with_tz = datetime.now().astimezone()

    session = Session()
    test1 = Test(date=now_utc)
    test2 = Test(date=now_without_tz)
    test3 = Test(date=now_with_tz)
    session.add(test1)
    session.add(test2)
    session.add(test3)
    session.commit()

    for test in session.query(Test).all():
        print(test.id, test.date)
```

It outputs:

```
2020-06-09 11:14:20,959 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
2020-06-09 11:14:20,959 INFO sqlalchemy.engine.base.Engine ()
2020-06-09 11:14:20,959 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
2020-06-09 11:14:20,959 INFO sqlalchemy.engine.base.Engine ()
2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine PRAGMA main.table_info("test")
2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine ()
2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine PRAGMA temp.table_info("test")
2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine ()
2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine 
CREATE TABLE test (
	id INTEGER NOT NULL, 
	date DATETIME, 
	PRIMARY KEY (id)
)


2020-06-09 11:14:20,960 INFO sqlalchemy.engine.base.Engine ()
2020-06-09 11:14:21,000 INFO sqlalchemy.engine.base.Engine COMMIT
2020-06-09 11:14:21,001 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)
2020-06-09 11:14:21,002 INFO sqlalchemy.engine.base.Engine INSERT INTO test (date) VALUES (?)
2020-06-09 11:14:21,002 INFO sqlalchemy.engine.base.Engine ('2020-06-09 09:14:21.000584',)
2020-06-09 11:14:21,003 INFO sqlalchemy.engine.base.Engine INSERT INTO test (date) VALUES (?)
2020-06-09 11:14:21,003 INFO sqlalchemy.engine.base.Engine ('2020-06-09 11:14:21.000600',)
2020-06-09 11:14:21,003 INFO sqlalchemy.engine.base.Engine INSERT INTO test (date) VALUES (?)
2020-06-09 11:14:21,004 INFO sqlalchemy.engine.base.Engine ('2020-06-09 09:14:21.000601',)
2020-06-09 11:14:21,004 INFO sqlalchemy.engine.base.Engine COMMIT
2020-06-09 11:14:21,014 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)
2020-06-09 11:14:21,015 INFO sqlalchemy.engine.base.Engine SELECT test.id AS test_id, test.date AS test_date 
FROM test
2020-06-09 11:14:21,015 INFO sqlalchemy.engine.base.Engine ()
1 2020-06-09 09:14:21.000584+00:00
2 2020-06-09 11:14:21.000600+00:00
3 2020-06-09 09:14:21.000601+00:00
```

The first datetime gived with UTC timezone is correctly saved. The second one without timezone is saved assuming it is an UTC timezone. And the third one in my local timezone (CET, UTC+2) is converted to UTC and then saved.

The three datetimes get a correct (UTC) timezone when fetching them from the database.
</details>

I tested it on my bridge installation and… it seems to work but I got another (I think unrelated) issue:
```
mautrix-facebook    | Traceback (most recent call last):
mautrix-facebook    |   File "/usr/lib/python3.8/site-packages/mautrix_facebook/user.py", line 353, in sync_threads
mautrix-facebook    |     await self._sync_thread(thread, ups, contacts)
mautrix-facebook    |   File "/usr/lib/python3.8/site-packages/mautrix_facebook/user.py", line 379, in _sync_thread
mautrix-facebook    |     await portal.backfill(self, is_initial=False, last_active=thread.last_active)
mautrix-facebook    |   File "/usr/lib/python3.8/site-packages/mautrix_facebook/portal.py", line 967, in backfill
mautrix-facebook    |     await self._backfill(source, limit, most_recent.date if most_recent else None)
mautrix-facebook    |   File "/usr/lib/python3.8/site-packages/mautrix_facebook/portal.py", line 991, in _backfill
mautrix-facebook    |     async with NotificationDisabler(self.mxid, source):
mautrix-facebook    |   File "/usr/lib/python3.8/site-packages/mautrix/bridge/notification_disabler.py", line 50, in __aenter__
mautrix-facebook    |     if not self.intent or not self.config_enabled:
mautrix-facebook    | AttributeError: 'NotificationDisabler' object has no attribute 'intent'
```

Fixes #57 