### PR TITLE
add prometheus

### DIFF
--- a/mautrix_facebook/__main__.py
+++ b/mautrix_facebook/__main__.py
@@ -15,9 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import asyncio
 import logging
+import random
+import time
 
 from mautrix.types import UserID, RoomID
 from mautrix.bridge import Bridge
+from prometheus_client import start_http_server as start_prometheus, Summary
 
 from .config import Config
 from .db import init as init_db
@@ -29,6 +32,9 @@ from .context import Context
 from .version import version, linkified_version
 from .web import PublicBridgeWebsite
 
+# Create a metric to track time spent and requests made.
+REQUEST_TIME = Summary('request_processing_seconds',
+                       'Time spent processing request')
 
 class MessengerBridge(Bridge):
     name = "mautrix-facebook"
@@ -149,5 +155,6 @@ class MessengerBridge(Bridge):
     def is_bridge_ghost(self, user_id: UserID) -> bool:
         return bool(Puppet.get_id_from_mxid(user_id))
 
+start_prometheus(8000)
 
 MessengerBridge().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ commonmark>=0.8,<0.10
 python-magic>=0.4,<0.5
 mautrix>=0.7,<0.8
 fbchat-asyncio>=0.6.17,<0.7
+prometheus_client>=0.8.0


### PR DESCRIPTION
really basic prometheus service, for now just providing the built-in stats and a stub!

Will add more metrics shortly, though feel free to merge this as-is if you're okay with it!

For those not familiar with prometheus, you'll now be able to reach `mautrix-facebook:8000/metrics` and collect point-in-time metrics from the process (including memory usage, thread count, file handle count, python gc metrics, and any future custom metrics we choose!).