### PR TITLE
Allow "outbound-only" users.

### DIFF
--- a/mautrix_facebook/commands/auth.py
+++ b/mautrix_facebook/commands/auth.py
@@ -173,6 +173,9 @@ async def logout(evt: CommandEvent) -> None:
                  help_section=SECTION_AUTH, help_text="Replace your Facebook Messenger account's "
                                                       "Matrix puppet with your Matrix account")
 async def login_matrix(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("Double-puppeting is disabled for this outbound-only account")
+        return
     puppet = pu.Puppet.get_by_fbid(evt.sender.fbid)
     _, homeserver = Client.parse_mxid(evt.sender.mxid)
     if homeserver != pu.Puppet.hs_domain:

--- a/mautrix_facebook/commands/conn.py
+++ b/mautrix_facebook/commands/conn.py
@@ -43,6 +43,9 @@ async def disconnect(evt: CommandEvent) -> None:
 @command_handler(needs_auth=True, management_only=True, help_section=SECTION_CONNECTION,
                  help_text="Connect to Facebook Messenger", aliases=["reconnect"])
 async def connect(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("Messenger MQTT connections are disabled for this outbound-only account")
+        return
     if evt.sender.listen_task and not evt.sender.listen_task.done():
         await evt.reply("You already have a Messenger MQTT connection")
         return

--- a/mautrix_facebook/commands/facebook.py
+++ b/mautrix_facebook/commands/facebook.py
@@ -56,6 +56,9 @@ async def _handle_search_result(sender: 'u.User', res: Iterable[fbchat.UserData]
 @command_handler(needs_auth=True, management_only=False, help_section=SECTION_MISC,
                  help_text="Synchronize portals", help_args="[_limit_] [--create] [--contacts]")
 async def sync(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("Syncing is disabled for this outbound-only account")
+        return
     contacts = False
     create_portals = False
     limit = evt.config["bridge.initial_chat_sync"]

--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -96,13 +96,14 @@ class Config(BaseBridgeConfig):
 
         copy_dict("bridge.permissions")
 
-    def _get_permissions(self, key: str) -> Tuple[bool, bool, str]:
+    def _get_permissions(self, key: str) -> Tuple[bool, bool, bool, str]:
         level = self["bridge.permissions"].get(key, "")
         admin = level == "admin"
-        user = level == "user" or admin
-        return user, admin, level
+        outbound = level == "outbound"
+        user = level == "user" or admin or outbound
+        return user, admin, outbound, level
 
-    def get_permissions(self, mxid: UserID) -> Tuple[bool, bool, str]:
+    def get_permissions(self, mxid: UserID) -> Tuple[bool, bool, bool, str]:
         permissions = self["bridge.permissions"] or {}
         if mxid in permissions:
             return self._get_permissions(mxid)

--- a/mautrix_facebook/db/user.py
+++ b/mautrix_facebook/db/user.py
@@ -37,7 +37,16 @@ class User(Base):
 
     @classmethod
     def get_by_fbid(cls, fbid: str) -> Optional['User']:
-        return cls._select_one_or_none(cls.c.fbid == fbid)
+        # Don't return an outbound-only user for this
+        # TODO Disallow multiple non-outbound users for the same fbid,
+        #      otherwise sync conflicts may occur
+        user = cls._select_one_or_none(cls.c.fbid == fbid)
+        if user and user.is_outbound:
+            for user in cls._select_all():
+                if not user.is_outbound:
+                    break
+
+        return user
 
     @classmethod
     def get_by_mxid(cls, mxid: UserID) -> Optional['User']:

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -218,6 +218,7 @@ bridge:
     # Permitted values:
     #       user - Use the bridge with puppeting.
     #      admin - Use and administrate the bridge.
+    #      outbound - Use the bridge only to send messages.
     # Permitted keys:
     #        * - All Matrix users
     #   domain - All users on that homeserver

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -653,7 +653,7 @@ class Portal(BasePortal):
     async def handle_matrix_leave(self, user: 'u.User') -> None:
         if self.is_direct:
             self.log.info(f"{user.mxid} left private chat portal with {self.fbid}")
-            if user.fbid == self.fb_receiver:
+            if not user.is_outbound and user.fbid == self.fb_receiver:
                 self.log.info(f"{user.mxid} was the recipient of this portal. "
                               "Cleaning up and deleting...")
                 await self.cleanup_and_delete()

--- a/mautrix_facebook/web/public.py
+++ b/mautrix_facebook/web/public.py
@@ -173,6 +173,9 @@ class PublicBridgeWebsite:
 
     async def reconnect(self, request: web.Request) -> web.Response:
         user = self.check_token(request)
+        if user.is_outbound:
+            return web.HTTPClientError(body='{"error": "Messenger MQTT connections are disabled for this outbound-only user"}',
+                                       headers=self._headers)
         if user.is_connected:
             raise web.HTTPConflict(body='{"error": "User is already connected"}',
                                    headers=self._headers)


### PR DESCRIPTION
These users can send messages, but do not sync any information.
They are useful for bot accounts that wish to send messages using the
same FB account as a "real" user already logged into the bridge.

---

This fixes some of the funkiness that can happen with `bridge.allow_invites: true` and a [matrix-imposter-bot](https://github.com/mrjohnson22/matrix-imposter-bot)-controlled "relay user", such as messages getting posted multiple times (similar to the issue I mentioned in https://github.com/tulir/mautrix-facebook/issues/96#issuecomment-691720003, but even without trying to double-puppet two users at once, which isn't even possible (nor should it be)).

The idea is to mark the "relay user" as an outbound only user, to prevent it from repeating any syncing operations that the "real" user logged into the same Facebook account should be doing. This also reduces some load on the server.

One big limitation is how this requires an edit of the config file, so it can only be enabled by bridge admins. Any other solution I could think of requires modifying at least one database table, which I wanted to avoid for the time being.