### PR TITLE
added ability to read configs from env

### DIFF
--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -13,7 +13,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Tuple, List
+from typing import Any, Tuple, List
+import os
 
 from mautrix.types import UserID
 from mautrix.util.config import ConfigUpdateHelper, ForbiddenDefault, ForbiddenKey
@@ -21,6 +22,12 @@ from mautrix.bridge.config import BaseBridgeConfig
 
 
 class Config(BaseBridgeConfig):
+    def __getitem__(self, key: str) -> Any:
+        try:
+            return os.environ[f"MAUTRIX_FACEBOOK_{key.replace('.', '_').upper()}"]
+        except KeyError:
+            return super().__getitem__(key)
+
     @property
     def forbidden_defaults(self) -> List[ForbiddenDefault]:
         return [


### PR DESCRIPTION
Added the ability to read configs from environment variables just like mautrix-telegram can ( https://github.com/tulir/mautrix-telegram/blob/master/mautrix_telegram/config.py#L29-L34 ).
This is very useful when you do not want to write down tokens in the configuration file.

This should maybe be placed in Mautrix config instead, as it seems like it would be useful for all mautrix-* to use.