### PR TITLE
Fix web: exception on bad requests

### DIFF
--- a/mautrix_facebook/web/public.py
+++ b/mautrix_facebook/web/public.py
@@ -82,21 +82,21 @@ class PublicBridgeWebsite:
             token = request.headers["Authorization"]
             token = token[len("Bearer "):]
         except KeyError:
-            raise web.HTTPBadRequest(body='{"error": "Missing Authorization header"}',
+            raise web.HTTPBadRequest(text='{"error": "Missing Authorization header"}',
                                      headers=self._headers)
         except IndexError:
-            raise web.HTTPBadRequest(body='{"error": "Malformed Authorization header"}',
+            raise web.HTTPBadRequest(text='{"error": "Malformed Authorization header"}',
                                      headers=self._headers)
         if self.shared_secret and token == self.shared_secret:
             try:
                 user_id = request.query["user_id"]
             except KeyError:
-                raise web.HTTPBadRequest(body='{"error": "Missing user_id query param"}',
+                raise web.HTTPBadRequest(text='{"error": "Missing user_id query param"}',
                                          headers=self._headers)
         else:
             user_id = self.verify_token(token)
             if not user_id:
-                raise web.HTTPForbidden(body='{"error": "Invalid token"}', headers=self._headers)
+                raise web.HTTPForbidden(text='{"error": "Invalid token"}', headers=self._headers)
 
         user = await u.User.get_by_mxid(user_id)
         return user


### PR DESCRIPTION
Currently bad requests to the web endpoint will throw exceptions like (making it difficult to play with):

```
[2021-01-20 18:02:40,637] [ERROR@aiohttp.server] Unhandled exception
Traceback (most recent call last):
  File "/path/matrix/mautrix-facebook/mautrix_facebook/web/public.py", line 92, in check_token
    user_id = request.query["user_id"]
KeyError: 'user_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.virtualenvs/bridge-fb/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
    resp = await self._request_handler(request)
  File "/root/.virtualenvs/bridge-fb/lib/python3.8/site-packages/aiohttp/web_app.py", line 499, in _handle
    resp = await handler(request)
  File "/path/matrix/mautrix-facebook/mautrix_facebook/web/public.py", line 105, in status
    user = await self.check_token(request)
  File "/path/matrix/mautrix-facebook/mautrix_facebook/web/public.py", line 94, in check_token
    raise web.HTTPBadRequest(body='{"error": "Missing user_id query param"}',
aiohttp.web_exceptions.HTTPBadRequest: Bad Request

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/path/.virtualenvs/bridge-fb/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 485, in start
    resp, reset = await task
  File "/path/.virtualenvs/bridge-fb/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 427, in _handle_request
    status=exc.status, reason=exc.reason, text=exc.text, headers=exc.headers
  File "/path/.virtualenvs/bridge-fb/lib/python3.8/site-packages/aiohttp/web_response.py", line 650, in text
    return self._body.decode(self.charset or "utf-8")
AttributeError: 'StringPayload' object has no attribute 'decode'
```