### PR TITLE
Allow "outbound-only" users.

### DIFF
--- a/mautrix_facebook/commands/conn.py
+++ b/mautrix_facebook/commands/conn.py
@@ -31,6 +31,9 @@ async def set_notice_room(evt: CommandEvent) -> None:
 @command_handler(needs_auth=True, management_only=True, help_section=SECTION_CONNECTION,
                  help_text="Disconnect from Facebook Messenger")
 async def disconnect(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("This command is not supported for outbound-only users.")
+        return
     if not evt.sender.mqtt:
         await evt.reply("You don't have a Messenger MQTT connection")
         return
@@ -40,6 +43,9 @@ async def disconnect(evt: CommandEvent) -> None:
 @command_handler(needs_auth=True, management_only=True, help_section=SECTION_CONNECTION,
                  help_text="Connect to Facebook Messenger", aliases=["reconnect"])
 async def connect(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("This command is not supported for outbound-only users.")
+        return
     if evt.sender.listen_task and not evt.sender.listen_task.done():
         await evt.reply("You already have a Messenger MQTT connection")
         return
@@ -60,7 +66,9 @@ async def ping(evt: CommandEvent) -> None:
     #     return
     await evt.reply(f"You're logged in as {own_info.name} (user ID {own_info.id})")
 
-    if not evt.sender.listen_task or evt.sender.listen_task.done():
+    if evt.sender.is_outbound:
+        await evt.reply("Messenger MQTT connections are disabled for this outbound-only account")
+    elif not evt.sender.listen_task or evt.sender.listen_task.done():
         await evt.reply("You don't have a Messenger MQTT connection. Use `connect` to connect.")
     elif not evt.sender.is_connected:
         await evt.reply("The Messenger MQTT listener is **disconnected**.")
@@ -71,4 +79,7 @@ async def ping(evt: CommandEvent) -> None:
 @command_handler(needs_auth=True, management_only=True, help_section=SECTION_CONNECTION,
                  help_text="\"Refresh\" the Facebook Messenger page")
 async def refresh(evt: CommandEvent) -> None:
+    if evt.sender.is_outbound:
+        await evt.reply("This command is not supported for outbound-only users.")
+        return
     await evt.sender.refresh(force_notice=True)

--- a/mautrix_facebook/db/upgrade/__init__.py
+++ b/mautrix_facebook/db/upgrade/__init__.py
@@ -2,4 +2,4 @@ from mautrix.util.async_db import UpgradeTable
 
 upgrade_table = UpgradeTable()
 
-from . import initial_revision
+from . import initial_revision, outbound_only

--- a/mautrix_facebook/db/upgrade/outbound_only.py
+++ b/mautrix_facebook/db/upgrade/outbound_only.py
@@ -1,0 +1,27 @@
+# mautrix-facebook - A Matrix-Facebook Messenger puppeting bridge.
+# Copyright (C) 2021 Tulir Asokan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from asyncpg import Connection
+from . import upgrade_table
+
+ref_mxid_exist_query = ("SELECT EXISTS(SELECT FROM information_schema.columns "
+                        "WHERE table_name='user' AND column_name='ref_mxid')")
+
+
+@upgrade_table.register(description="Revision to allow outbound-only users", transaction=False)
+async def upgrade_outbound_only(conn: Connection) -> None:
+    ref_mxid_exist = await conn.fetchval(ref_mxid_exist_query)
+    if not ref_mxid_exist:
+        await conn.execute('ALTER TABLE "user" ADD COLUMN ref_mxid TEXT')

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -636,7 +636,7 @@ class Portal(DBPortal, BasePortal):
     async def handle_matrix_leave(self, user: 'u.User') -> None:
         if self.is_direct:
             self.log.info(f"{user.mxid} left private chat portal with {self.fbid}")
-            if user.fbid == self.fb_receiver:
+            if not user.is_outbound and user.fbid == self.fb_receiver:
                 self.log.info(f"{user.mxid} was the recipient of this portal. "
                               "Cleaning up and deleting...")
                 await self.cleanup_and_delete()

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -138,6 +138,7 @@ class User(DBUser, BaseUser):
         self.mqtt = ref_user.mqtt
         #self.listen_task = ref_user.listen_task
         #self.seq_id = ref_user.seq_id
+        self._is_logged_in = ref_user.is_logged_in()
 
     @classmethod
     def init_cls(cls, bridge: 'MessengerBridge') -> AsyncIterable[Awaitable[bool]]:

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -99,8 +99,9 @@ class User(DBUser, BaseUser):
 
     def __init__(self, mxid: UserID, fbid: Optional[int] = None,
                  state: Optional[AndroidState] = None,
-                 notice_room: Optional[RoomID] = None) -> None:
-        super().__init__(mxid=mxid, fbid=fbid, state=state, notice_room=notice_room)
+                 notice_room: Optional[RoomID] = None,
+                 ref_mxid: Optional[UserID] = None) -> None:
+        super().__init__(mxid=mxid, fbid=fbid, state=state, notice_room=notice_room, ref_mxid=ref_mxid)
         self.notice_room = notice_room
         self._notice_room_lock = asyncio.Lock()
         self._notice_send_lock = asyncio.Lock()
@@ -126,6 +127,18 @@ class User(DBUser, BaseUser):
         self.listen_task = None
         self.seq_id = None
 
+    async def init_from_ref_user(self) -> None:
+        ref_user = await User.get_by_mxid(self.ref_mxid)
+        self._copy_from(ref_user)
+
+    def _copy_from(self, ref_user: 'User') -> None:
+        self.fbid = ref_user.fbid
+        self.state = ref_user.state
+        self.client = ref_user.client
+        self.mqtt = ref_user.mqtt
+        #self.listen_task = ref_user.listen_task
+        #self.seq_id = ref_user.seq_id
+
     @classmethod
     def init_cls(cls, bridge: 'MessengerBridge') -> AsyncIterable[Awaitable[bool]]:
         cls.bridge = bridge
@@ -146,12 +159,22 @@ class User(DBUser, BaseUser):
             self._is_connected = val
             self._connection_time = time.monotonic()
 
+    @property
+    def is_outbound(self):
+        return self.ref_mxid is not None
+
     # region Database getters
 
     def _add_to_cache(self) -> None:
-        self.by_mxid[self.mxid] = self
-        if self.fbid:
-            self.by_fbid[self.fbid] = self
+        if not self.is_outbound:
+            self.by_mxid[self.mxid] = self
+            if self.fbid:
+                self.by_fbid[self.fbid] = self
+        else:
+            try:
+                del self.by_mxid[self.mxid]
+            except KeyError:
+                pass
 
     @classmethod
     async def all_logged_in(cls) -> AsyncGenerator['User', None]:
@@ -233,8 +256,7 @@ class User(DBUser, BaseUser):
             self._track_metric(METRIC_LOGGED_IN, True)
             self._is_logged_in = True
             self.is_connected = None
-            self.stop_listen()
-            asyncio.ensure_future(self.post_login(), loop=self.loop)
+            self._prepare_listening()
             return True
         return False
 
@@ -305,6 +327,13 @@ class User(DBUser, BaseUser):
         self._is_refreshing = False
 
     async def logout(self, remove_fbid: bool = True) -> bool:
+        if self.is_outbound:
+            self.fbid = None
+            self.client = None
+            self.ref_mxid = None
+            await self.save()
+            return True
+
         ok = True
         self.stop_listen()
         if self.state:
@@ -333,7 +362,6 @@ class User(DBUser, BaseUser):
 
     async def post_login(self) -> None:
         self.log.info("Running post-login actions")
-        self._add_to_cache()
 
         try:
             puppet = await pu.Puppet.get_by_fbid(self.fbid)
@@ -590,13 +618,29 @@ class User(DBUser, BaseUser):
         self.mqtt = None
         self.listen_task = None
 
+    def _prepare_listening(self) -> None:
+        if self.is_outbound:
+            self.log.debug(f"Not running post-login actions for outbound-only user")
+        else:
+            self.stop_listen()
+            asyncio.ensure_future(self.post_login(), loop=self.loop)
+        self._add_to_cache()
+
     async def on_logged_in(self, state: AndroidState) -> None:
-        self.fbid = state.session.uid
-        self.state = state
-        self.client = AndroidAPI(state, log=self.log.getChild("api"))
-        await self.save()
-        self.stop_listen()
-        asyncio.ensure_future(self.post_login(), loop=self.loop)
+        ref_user = await User.get_by_fbid(state.session.uid)
+        if ref_user is not None:
+            # TODO log out if there is a logout API for messenger mobile
+            self.log.debug(f"Setting user {self.mxid} as an outbound-only user sharing the connection of user {ref_user.mxid}")
+            self.ref_mxid = ref_user.mxid
+            await self.save()
+            # Save to DB *before* copying settings
+            self._copy_from(ref_user)
+        else:
+            self.fbid = state.session.uid
+            self.state = state
+            self.client = AndroidAPI(state, log=self.log.getChild("api"))
+            await self.save()
+            self._prepare_listening()
 
     @async_time(METRIC_MESSAGE)
     async def on_message(self, evt: Union[mqtt_t.Message, mqtt_t.ExtendedMessage]) -> None:

--- a/mautrix_facebook/web/public.py
+++ b/mautrix_facebook/web/public.py
@@ -269,14 +269,17 @@ class PublicBridgeWebsite:
     async def logout(self, request: web.Request) -> web.Response:
         user = await self.check_token(request)
 
-        puppet = await pu.Puppet.get_by_fbid(user.fbid)
+        puppet = await pu.Puppet.get_by_fbid(user.fbid) if not user.is_outbound else None
         await user.logout()
-        if puppet.is_real_user:
+        if puppet and puppet.is_real_user:
             await puppet.switch_mxid(None, None)
         return web.json_response({}, headers=self._acao_headers)
 
     async def disconnect(self, request: web.Request) -> web.Response:
         user = await self.check_token(request)
+        if user.is_outbound:
+            return web.HTTPClientError(body='{"error": "This command is not supported for outbound-only users.}',
+                                       headers=self._headers)
         if not user.is_connected:
             raise web.HTTPBadRequest(text='{"error": "User is not connected"}',
                                      headers=self._headers)
@@ -286,6 +289,9 @@ class PublicBridgeWebsite:
 
     async def reconnect(self, request: web.Request) -> web.Response:
         user = await self.check_token(request)
+        if user.is_outbound:
+            return web.HTTPClientError(body='{"error": "This command is not supported for outbound-only users.}',
+                                       headers=self._headers)
         if user.is_connected:
             raise web.HTTPConflict(text='{"error": "User is already connected"}',
                                    headers=self._headers)
@@ -294,5 +300,8 @@ class PublicBridgeWebsite:
 
     async def refresh(self, request: web.Request) -> web.Response:
         user = await self.check_token(request)
+        if user.is_outbound:
+            return web.HTTPClientError(body='{"error": "This command is not supported for outbound-only users.}',
+                                       headers=self._headers)
         await user.try_refresh()
         return web.json_response({}, headers=self._acao_headers)


### PR DESCRIPTION
These users can send messages, but do not sync any information.
They are useful for bot accounts that wish to send messages using the
same FB account as a "real" user already logged into the bridge.

This also updates the "user" database table.