### PR TITLE
Don't disconnect user's MQTT if it's None

### DIFF
--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -297,7 +297,8 @@ class User(DBUser, BaseUser):
 
     async def reconnect(self) -> None:
         self._is_refreshing = True
-        self.mqtt.disconnect()
+        if self.mqtt:
+            self.mqtt.disconnect()
         await self.listen_task
         self.listen_task = None
         self.mqtt = None


### PR DESCRIPTION
Should help when using `bridge.periodic_reconnect.mode = reconnect` and
`bridge.periodic_reconnect.always = true`