### PR TITLE
Use HTTP proxy (if any) in BaseAndroidAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-magic>=0.4,<0.5
 mautrix>=0.9.1,<0.10
 pycryptodome>=3,<4
 paho-mqtt>=1.5,<2
+aiohttp_socks>=0.6.0


### PR DESCRIPTION
Hi

First of all, thanks for this amazing bridge! I upgraded this bridge from < 0.2.0 to the latest release. I"m hosting my Matrix home server on a VPS in a different country than my home-country. Therefore, I have to run the bridge using a SOCKS5 proxy to some IP address in my home country. This worked perfectly with the <0.2.0 release and facebook never blocked the account.
However, with the latest release I noticed that I was logged into facebook using a pixel 3 from the country of my VPS. Looking at the code I still saw the proxy setup in the MQTT client, but I noticed there was no such code when doing HTTP requests to login at facebook. This PR fixes this issue. 

I integrated the https://github.com/romis2012/aiohttp-socks library and it's working fine now. 
Of course feel free to change the code to your liking, I don't know much about python async code.