### PR TITLE
Capture aiohttp connection errors when reloading the session.

### DIFF
--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -18,6 +18,8 @@ from typing import (Dict, List, Optional, AsyncIterable, Awaitable, Union, TypeV
 import asyncio
 import time
 
+from aiohttp import ClientConnectionError
+
 from mautrix.errors import MNotFound
 from mautrix.types import (PushActionType, PushRuleKind, PushRuleScope, UserID, RoomID, EventID,
                            TextMessageEventContent, MessageType)
@@ -226,7 +228,8 @@ class User(DBUser, BaseUser):
             try:
                 user_info = await client.get_self()
                 break
-            except (ProxyError, ProxyTimeoutError, ProxyConnectionError, ConnectionError) as e:
+            except (ProxyError, ProxyTimeoutError, ProxyConnectionError,
+                    ClientConnectionError, ConnectionError) as e:
                 attempt += 1
                 wait = min(attempt * 10, 60)
                 self.log.warning(f"{e.__class__.__name__} while trying to restore session, "


### PR DESCRIPTION
The aiohttp exceptions don't inherit from the Python builtin `ConnectionError`
meaning these instantly fail session restore.