### PR TITLE
Handle `listen_task = None` while reconnecting

### DIFF
--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -442,7 +442,8 @@ class User(DBUser, BaseUser):
         self._is_refreshing = True
         if self.mqtt:
             self.mqtt.disconnect()
-        await self.listen_task
+        if self.listen_task:
+            await self.listen_task
         self.listen_task = None
         self.mqtt = None
         if fetch_user:


### PR DESCRIPTION
Got this error, not sure why, but I think it should be safe to skip the await and continue the reconnect method if `self.listen_task` is `None`.

```
[ERROR@mau.periodic_reconnect] Error while reconnecting @nick:homeserver
Traceback (most recent call last):
  File "/path/mautrix-facebook/mautrix_facebook/__main__.py", line 159, in _periodic_reconnect_loop
    await user.reconnect()
  File "/path/mautrix-facebook/mautrix_facebook/user.py", line 445, in reconnect
    await self.listen_task
 TypeError: object NoneType can't be used in 'await' expression
```

(I'm running on newest master, i.e. 75627451611ca79176347df387efa12db04f94ce)